### PR TITLE
save reusable, check if name exists, fail if so

### DIFF
--- a/libs/builder/builder.js
+++ b/libs/builder/builder.js
@@ -2118,6 +2118,11 @@ Vvveb.Builder = {
 	},
 
 	saveElement: function(element, type, name, callback) {
+		
+		if(Vvveb.Sections.get('reusable/'+ name) || Vvveb.Blocks.get('reusable/'+ name)){
+			displayToast("bg-danger", "Error", "Reusable name already exists");
+		}
+		
 		if (type == 'section') {
 			Vvveb.Sections.add('reusable/'+ name, {
 				name,


### PR DESCRIPTION
catalog does not support elements of same name, even though it will add another block of same name to the left column, all with same name will be overwritten to same html

if this is intended (which might be chosen instead of adding a delete function) than there needs to be a confirm/warning first

and a duplicate block not added to the left column