### PR TITLE
initSwiper bug fix

### DIFF
--- a/libs/builder/components-elements.js
+++ b/libs/builder/components-elements.js
@@ -1049,7 +1049,7 @@ function carouselAfterDrop(node) {
 				};
 				for (i in el.dataset) {
 					let param = el.dataset[i];
-					if (param[0] = '{') {
+					if (param[0] == '{') {
 						param = JSON.parse(param);
 					}
 					params[i] = param;
@@ -1062,7 +1062,7 @@ function carouselAfterDrop(node) {
 		if (document.readyState !== 'loading') {
 			initSwiper();
 		  } else {
-			document.addEventListener('DOMContentLoaded', initSwiper);
+			document.addEventListener('DOMContentLoaded', () => initSwiper());
 		  }`;			
 		
 		body.appendChild(link);


### PR DESCRIPTION
execution via the eventlistener sends the event object which breaks initSwiper's 'onlyNew' parameter, stopping existing swiper from initialising.

also there was a problem with single = in param check i corrected