### PR TITLE
wysiwyg, hide font size selector

### DIFF
--- a/editor.html
+++ b/editor.html
@@ -578,7 +578,7 @@
 										
 										<div class="separator"></div>
 
-										<select id="font-size" class="form-select" aria-label="Font size">
+										<select id="font-size" class="form-select" aria-label="Font size" style="display:none;">
 											<option value="">- Font size -</option>
 											<option value="8px">8 px</option>
 											<option value="9px">9 px</option>


### PR DESCRIPTION
this conflicts with mobile view / media queries, as as changes via wysiwyg editor doesnt take into affect mobile/tablet view, and because they are inline media queries wont be able to affect them.