### PR TITLE
initSlider autoplay fix

### DIFF
--- a/libs/builder/components-elements.js
+++ b/libs/builder/components-elements.js
@@ -1054,8 +1054,8 @@ function carouselAfterDrop(node) {
 					}
 					params[i] = param;
 				}
+                if(params.autoplay == 'true')params.autoplay = {'delay':params.delay};
 				swiper.push(new Swiper(el, params))
-				//swiper.push(new Swiper(el, { ...{autoplay:{delay: 500}}, ...el.dataset}))		
 			});
 		}
 
@@ -1178,7 +1178,7 @@ Vvveb.Components.add("elements/carousel", {
 		htmlAttr:"data-speed",
 		data: {step:100},
 	},{
-		name: "Delay",
+		name: "Autoplay Delay",
         key: "delay",
         inputtype: NumberInput,
 		htmlAttr:"data-delay",


### PR DESCRIPTION
I do wonder if initSlider func shouldnt be inline js injected into the page content, as once inserted it can update when the repo updates, and the func should be moved to a js file, similarly because the slider css is inserted mid body, its after the head where the editor.style.bundle.css so its harder to override