### PR TITLE
initSwiper click propogation blocking fix

### DIFF
--- a/libs/builder/components-elements.js
+++ b/libs/builder/components-elements.js
@@ -1054,6 +1054,11 @@ function carouselAfterDrop(node) {
 					}
 					params[i] = param;
 				}
+                if (window.self !== window.top){//is editor (maybe a better test, as could have iframe on front end too)
+                        params.simulateTouch = false;//quick fix for swiper blocking propogation of events to vvvebs, disable swipe, nav buttons still work
+                 }else{
+                        if(params.autoplay == 'true')params.autoplay = {'delay':params.delay};//autoplay in front end only for usability
+                 }
 				swiper.push(new Swiper(el, params))
 				//swiper.push(new Swiper(el, { ...{autoplay:{delay: 500}}, ...el.dataset}))		
 			});


### PR DESCRIPTION
i found out the swiper module when active and draggable enabled will stop propogation of clicks to the highlightup or highlightclick functions (i cant remember which) such that changes made to an element and then click another element the change are lost.

(i also made it only enable autoplay on front end)